### PR TITLE
1.2.1 development changes

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## **1.2.1** - 2024-09-06
+
+### Added:
+* Minimum values are enforced on startup for settings that could lead to crashes
+* Extended the Color Picker tool with two alternate modes
+  * Holding **Shift** searches layer by layer for the highest non-transparent color at the specified pixel; does nothing if no such pixel is found
+  * Holding **Ctrl** samples the pixel from the flattened project
+* Normal map color sampler with quantization option
+
+### Fixed:
+* Bug: Attempting to validate a script with no return type crashes the program
+* Bug: Crashes due to impossible layout/sizing logic
+
 ## **1.2.0** - 2024-09-03
 
 ### Added:

--- a/res/blurbs/__changelog.txt
+++ b/res/blurbs/__changelog.txt
@@ -2,6 +2,7 @@
 
 Fixed:
 > Bug: Attempting to validate a script with no return type crashes the program
+> Now enforces minimum sizing; addresses crashes due to impossible layout/sizing logic
 
 {1.2.0} - 2024-09-03
 

--- a/res/blurbs/__changelog.txt
+++ b/res/blurbs/__changelog.txt
@@ -1,7 +1,12 @@
-{1.2.1} - 2024-09-??
+{1.2.1} - 2024-09-06
 
 Added:
 > Minimum values are enforced on startup for settings that could lead to crashes
+> Extended the Color Picker tool with two alternate modes
+  > Holding {Shift} searches layer by layer for the highest non-transparent color at the specified
+    pixel; does nothing if no such pixel is found
+  > Holding {Ctrl} samples the pixel from the flattened project
+> Normal map color sampler with quantization option
 
 Fixed:
 > Bug: Attempting to validate a script with no return type crashes the program

--- a/res/blurbs/__changelog.txt
+++ b/res/blurbs/__changelog.txt
@@ -1,3 +1,8 @@
+{1.2.1} - 2024-09-??
+
+Fixed:
+> Bug: Attempting to validate a script with no return type crashes the program
+
 {1.2.0} - 2024-09-03
 
 Added:

--- a/res/blurbs/__changelog.txt
+++ b/res/blurbs/__changelog.txt
@@ -1,8 +1,11 @@
 {1.2.1} - 2024-09-??
 
+Added:
+> Minimum values are enforced on startup for settings that could lead to crashes
+
 Fixed:
 > Bug: Attempting to validate a script with no return type crashes the program
-> Now enforces minimum sizing; addresses crashes due to impossible layout/sizing logic
+> Bug: Crashes due to impossible layout/sizing logic
 
 {1.2.0} - 2024-09-03
 

--- a/res/blurbs/color_picker.txt
+++ b/res/blurbs/color_picker.txt
@@ -5,3 +5,8 @@ pixel that was clicked.
 
 Assign to primary: {Left Click}
 Assign to secondary: {Right Click}
+
+Hold {Shift} to search layer by layer for the highest non-transparent color at the specified pixel;
+does nothing if no such pixel is found.
+
+Hold {Ctrl} to sample the pixel from the flattened project.

--- a/res/program
+++ b/res/program
@@ -1,5 +1,5 @@
 name:{Stipple Effect}
-version:{1.2.1.5}
+version:{1.2.1.10}
 devbuild:{true}
 native_standard:{1.3}
 palette_standard:{1.0}

--- a/res/program
+++ b/res/program
@@ -1,5 +1,5 @@
 name:{Stipple Effect}
-version:{1.2.1.33}
+version:{1.2.1.37}
 devbuild:{true}
 native_standard:{1.3}
 palette_standard:{1.0}

--- a/res/program
+++ b/res/program
@@ -1,5 +1,5 @@
 name:{Stipple Effect}
-version:{1.2.1.54}
+version:{1.2.1.63}
 devbuild:{true}
 native_standard:{1.3}
 palette_standard:{1.0}

--- a/res/program
+++ b/res/program
@@ -1,5 +1,5 @@
 name:{Stipple Effect}
-version:{1.2.1.37}
+version:{1.2.1.44}
 devbuild:{true}
 native_standard:{1.3}
 palette_standard:{1.0}

--- a/res/program
+++ b/res/program
@@ -1,5 +1,5 @@
 name:{Stipple Effect}
-version:{1.2.1.10}
+version:{1.2.1.18}
 devbuild:{true}
 native_standard:{1.3}
 palette_standard:{1.0}

--- a/res/program
+++ b/res/program
@@ -1,5 +1,5 @@
 name:{Stipple Effect}
-version:{1.2.1.63}
-devbuild:{true}
+version:{1.2.1}
+devbuild:{false}
 native_standard:{1.3}
 palette_standard:{1.0}

--- a/res/program
+++ b/res/program
@@ -1,5 +1,5 @@
 name:{Stipple Effect}
-version:{1.2.1.22}
+version:{1.2.1.33}
 devbuild:{true}
 native_standard:{1.3}
 palette_standard:{1.0}

--- a/res/program
+++ b/res/program
@@ -1,5 +1,5 @@
 name:{Stipple Effect}
-version:{1.2.1.2}
+version:{1.2.1.5}
 devbuild:{true}
 native_standard:{1.3}
 palette_standard:{1.0}

--- a/res/program
+++ b/res/program
@@ -1,5 +1,5 @@
 name:{Stipple Effect}
-version:{1.2.0}
-devbuild:{false}
+version:{1.2.1.1}
+devbuild:{true}
 native_standard:{1.3}
 palette_standard:{1.0}

--- a/res/program
+++ b/res/program
@@ -1,5 +1,5 @@
 name:{Stipple Effect}
-version:{1.2.1.44}
+version:{1.2.1.54}
 devbuild:{true}
 native_standard:{1.3}
 palette_standard:{1.0}

--- a/res/program
+++ b/res/program
@@ -1,5 +1,5 @@
 name:{Stipple Effect}
-version:{1.2.1.18}
+version:{1.2.1.22}
 devbuild:{true}
 native_standard:{1.3}
 palette_standard:{1.0}

--- a/res/program
+++ b/res/program
@@ -1,5 +1,5 @@
 name:{Stipple Effect}
-version:{1.2.1.1}
+version:{1.2.1.2}
 devbuild:{true}
 native_standard:{1.3}
 palette_standard:{1.0}

--- a/src/com/jordanbunke/stipple_effect/scripting/SEInterpreter.java
+++ b/src/com/jordanbunke/stipple_effect/scripting/SEInterpreter.java
@@ -52,7 +52,7 @@ public final class SEInterpreter extends Interpreter {
         final TypeNode COL_TYPE = TypeNode.getColor();
 
         return script.paramsMatch(new TypeNode[] { COL_TYPE }) &&
-                script.getReturnType().equals(COL_TYPE);
+                COL_TYPE.equals(script.getReturnType());
     }
 
     public static boolean validatePreviewScript(
@@ -65,8 +65,8 @@ public final class SEInterpreter extends Interpreter {
                 IMG_ARRAY_TYPE = TypeNode.arrayOf(IMG_TYPE),
                 returnType = script.getReturnType();
 
-        final boolean imgReturn = returnType.equals(IMG_TYPE),
-                arrayReturn = returnType.equals(IMG_ARRAY_TYPE),
+        final boolean imgReturn = IMG_TYPE.equals(returnType),
+                arrayReturn = IMG_ARRAY_TYPE.equals(returnType),
                 imgParam = script.paramsMatch(new TypeNode[] { IMG_TYPE }),
                 arrayParam = script.paramsMatch(new TypeNode[] { IMG_ARRAY_TYPE });
 

--- a/src/com/jordanbunke/stipple_effect/tools/ColorPicker.java
+++ b/src/com/jordanbunke/stipple_effect/tools/ColorPicker.java
@@ -3,19 +3,57 @@ package com.jordanbunke.stipple_effect.tools;
 import com.jordanbunke.delta_time.events.GameMouseEvent;
 import com.jordanbunke.delta_time.utility.math.Coord2D;
 import com.jordanbunke.stipple_effect.StippleEffect;
+import com.jordanbunke.stipple_effect.layer.SELayer;
 import com.jordanbunke.stipple_effect.project.SEContext;
 
 import java.awt.*;
+import java.util.List;
 
-public final class ColorPicker extends Tool {
+public final class ColorPicker extends Tool
+        implements SnappableTool, ToggleModeTool {
     private static final ColorPicker INSTANCE;
+
+    private Mode mode;
+    private boolean ctrl, shift;
 
     static {
         INSTANCE = new ColorPicker();
     }
 
-    private ColorPicker() {
+    private enum Mode {
+        REGULAR, COMPOSED, LAYERS;
 
+        public Color get(final Coord2D tp, final SEContext c) {
+            return switch (this) {
+                case REGULAR -> c.getState().getActiveCel()
+                        .getColorAt(tp.x, tp.y);
+                case LAYERS -> {
+                    final int frameIndex = c.getState().getFrameIndex();
+                    final List<SELayer> layers = c.getState().getLayers();
+
+                    for (int l = layers.size() - 1; l >= 0; l--) {
+                        final Color sampled = layers.get(l)
+                                .getCel(frameIndex).getColorAt(tp.x, tp.y);
+                        if (sampled.getAlpha() > 0)
+                            yield sampled;
+                    }
+
+                    yield null;
+                }
+                case COMPOSED -> {
+                    final int frameIndex = c.getState().getFrameIndex();
+                    yield c.getState().draw(false, false,
+                            frameIndex).getColorAt(tp.x, tp.y);
+                }
+            };
+        }
+    }
+
+    private ColorPicker() {
+        mode = Mode.REGULAR;
+
+        ctrl = false;
+        shift = true;
     }
 
     public static ColorPicker get() {
@@ -35,10 +73,34 @@ public final class ColorPicker extends Tool {
             final int index = me.button == GameMouseEvent.Button.LEFT
                     ? StippleEffect.PRIMARY : StippleEffect.SECONDARY;
 
-            final Color c = context.getState().getActiveCel()
-                    .getColorAt(tp.x, tp.y);
+            final Color c = mode.get(tp, context);
 
-            StippleEffect.get().setColorIndexAndColor(index, c);
+            if (c != null)
+                StippleEffect.get().setColorIndexAndColor(index, c);
         }
+    }
+
+    @Override
+    public void setSnap(final boolean snap) {
+        shift = snap;
+        updateMode();
+    }
+
+    @Override
+    public boolean isSnap() {
+        return shift;
+    }
+
+    @Override
+    public void setMode(final boolean mode) {
+        ctrl = mode;
+        updateMode();
+    }
+
+    private void updateMode() {
+        if (ctrl ^ shift)
+            mode = ctrl ? Mode.COMPOSED : Mode.LAYERS;
+        else
+            mode = Mode.REGULAR;
     }
 }

--- a/src/com/jordanbunke/stipple_effect/utility/Layout.java
+++ b/src/com/jordanbunke/stipple_effect/utility/Layout.java
@@ -25,10 +25,11 @@ public final class Layout {
     public static final int
             COLLAPSED_PROJECTS_H = 27, BOTTOM_BAR_H = 24, TOOL_OPTIONS_BAR_H = 30,
             COLOR_COMP_W_ALLOWANCE = RIGHT_PANEL_W, SCREEN_H_BUFFER = 120,
-            MAX_WINDOW_H = Toolkit.getDefaultToolkit().getScreenSize().height - SCREEN_H_BUFFER,
             MIN_WINDOW_H = 788,
-            MAX_WINDOW_W = (int)(MAX_WINDOW_H * (16 / 9.)),
+            MAX_WINDOW_H = Math.max(MIN_WINDOW_H,
+                    Toolkit.getDefaultToolkit().getScreenSize().height - SCREEN_H_BUFFER),
             MIN_WINDOW_W = (int)(MIN_WINDOW_H * (16 / 9.)),
+            MAX_WINDOW_W = Math.max(MIN_WINDOW_W, (int)(MAX_WINDOW_H * (16 / 9.))),
             TEXT_Y_OFFSET = -4, TOOL_TIP_OFFSET = 8,
             TEXT_CARET_W = 1, TEXT_CARET_H = 23,
             TEXT_CARET_Y_OFFSET = -11, TEXT_LINE_PX_H = TEXT_CARET_H + 2,

--- a/src/com/jordanbunke/stipple_effect/utility/SamplerMode.java
+++ b/src/com/jordanbunke/stipple_effect/utility/SamplerMode.java
@@ -4,7 +4,7 @@ import com.jordanbunke.delta_time.utility.math.Coord2D;
 import com.jordanbunke.stipple_effect.visual.menu_elements.colors.ColorComponent;
 
 public enum SamplerMode {
-    RGB_SLIDERS, HSV_SLIDERS, SV_MATRIX, COLOR_WHEEL;
+    RGB_SLIDERS, HSV_SLIDERS, SV_MATRIX, COLOR_WHEEL, NORMAL;
 
     @Override
     public String toString() {
@@ -13,6 +13,7 @@ public enum SamplerMode {
             case HSV_SLIDERS -> "HSV sliders";
             case SV_MATRIX -> "SV matrix";
             case COLOR_WHEEL -> "Color wheel";
+            case NORMAL -> "Normal map";
         };
     }
 

--- a/src/com/jordanbunke/stipple_effect/utility/settings/Settings.java
+++ b/src/com/jordanbunke/stipple_effect/utility/settings/Settings.java
@@ -140,7 +140,22 @@ public class Settings {
         }
 
         private void read(final String value) {
-            setting.setFromRead(value);
+            switch (this) {
+                case WINDOWED_W -> readWindowDim(value, Layout.MIN_WINDOW_W);
+                case WINDOWED_H -> readWindowDim(value, Layout.MIN_WINDOW_H);
+                default -> setting.setFromRead(value);
+            }
+        }
+
+        private void readWindowDim(final String value, final int minimum) {
+            try {
+                final int dim = Integer.parseInt(value);
+
+                if (dim >= minimum)
+                    setting.setFromRead(value);
+            } catch (NumberFormatException ignored) {
+
+            }
         }
     }
 

--- a/src/com/jordanbunke/stipple_effect/utility/settings/Settings.java
+++ b/src/com/jordanbunke/stipple_effect/utility/settings/Settings.java
@@ -141,13 +141,17 @@ public class Settings {
 
         private void read(final String value) {
             switch (this) {
-                case WINDOWED_W -> readWindowDim(value, Layout.MIN_WINDOW_W);
-                case WINDOWED_H -> readWindowDim(value, Layout.MIN_WINDOW_H);
+                case WINDOWED_W -> readWithMinimum(value, Layout.MIN_WINDOW_W);
+                case WINDOWED_H -> readWithMinimum(value, Layout.MIN_WINDOW_H);
+                case DEFAULT_CANVAS_W_PX, DEFAULT_CANVAS_H_PX,
+                        CHECKERBOARD_W_PX, CHECKERBOARD_H_PX,
+                        PIXEL_GRID_X_PX, PIXEL_GRID_Y_PX,
+                        DEFAULT_TOOL_BREADTH -> readWithMinimum(value, 1);
                 default -> setting.setFromRead(value);
             }
         }
 
-        private void readWindowDim(final String value, final int minimum) {
+        private void readWithMinimum(final String value, final int minimum) {
             try {
                 final int dim = Integer.parseInt(value);
 

--- a/src/com/jordanbunke/stipple_effect/visual/MenuAssembly.java
+++ b/src/com/jordanbunke/stipple_effect/visual/MenuAssembly.java
@@ -642,11 +642,14 @@ public class MenuAssembly {
         samplerContentMap.put(SamplerMode.SV_MATRIX,
                 new MenuElementGrouping(matrix, mHue, mAlpha));
 
-        // color wheel
+        // color wheels
         final int wheelWidth = contentWidthAllowance(
                 panelPos.x, pw, samplerStartingPos.x);
         final ColorWheel wheel = new ColorWheel(samplerStartingPos,
                 new Bounds2D(wheelWidth, biggestIncY * 3));
+        final NormalMapSampler normalMap =
+                new NormalMapSampler(samplerStartingPos,
+                        new Bounds2D(wheelWidth, biggestIncY * 3));
 
         final Coord2D wValuePos = samplerStartingPos.displace(
                 0, wheel.getHeight()),
@@ -656,6 +659,8 @@ public class MenuAssembly {
 
         samplerContentMap.put(SamplerMode.COLOR_WHEEL,
                 new MenuElementGrouping(wheel, wValue, wAlpha));
+        samplerContentMap.put(SamplerMode.NORMAL,
+                new MenuElementGrouping(normalMap, wValue, wAlpha));
 
 
         // sampler manager

--- a/src/com/jordanbunke/stipple_effect/visual/MenuAssembly.java
+++ b/src/com/jordanbunke/stipple_effect/visual/MenuAssembly.java
@@ -659,8 +659,20 @@ public class MenuAssembly {
 
         samplerContentMap.put(SamplerMode.COLOR_WHEEL,
                 new MenuElementGrouping(wheel, wValue, wAlpha));
+
+        final TextLabel quantLabel = TextLabel.make(
+                wValuePos.displace(0, DIALOG_CONTENT_INC_Y / 2), "Quantize");
+        final IncrementalRangeElements<Integer> q =
+                IncrementalRangeElements.makeForInt(quantLabel,
+                        quantLabel.getY() + ICON_BUTTON_OFFSET_Y,
+                        quantLabel.getY() + TEXT_Y_OFFSET, 1,
+                        NormalMapSampler.NONE, NormalMapSampler.MAX,
+                        normalMap::setQuantization, normalMap::getQuantization,
+                        i -> i, i -> i, i -> "", "");
+
         samplerContentMap.put(SamplerMode.NORMAL,
-                new MenuElementGrouping(normalMap, wValue, wAlpha));
+                new MenuElementGrouping(normalMap, quantLabel,
+                        q.decButton, q.incButton, q.slider, q.value, wAlpha));
 
 
         // sampler manager

--- a/src/com/jordanbunke/stipple_effect/visual/MenuAssembly.java
+++ b/src/com/jordanbunke/stipple_effect/visual/MenuAssembly.java
@@ -664,8 +664,8 @@ public class MenuAssembly {
                 wValuePos.displace(0, DIALOG_CONTENT_INC_Y / 2), "Quantize");
         final IncrementalRangeElements<Integer> q =
                 IncrementalRangeElements.makeForInt(quantLabel,
-                        quantLabel.getY() + ICON_BUTTON_OFFSET_Y,
-                        quantLabel.getY() + TEXT_Y_OFFSET, 1,
+                        quantLabel.getY() + DIALOG_CONTENT_COMP_OFFSET_Y,
+                        quantLabel.getY(), 1,
                         NormalMapSampler.NONE, NormalMapSampler.MAX,
                         normalMap::setQuantization, normalMap::getQuantization,
                         i -> i, i -> i, i -> "", "");

--- a/src/com/jordanbunke/stipple_effect/visual/menu_elements/colors/AbstractColorMap.java
+++ b/src/com/jordanbunke/stipple_effect/visual/menu_elements/colors/AbstractColorMap.java
@@ -37,7 +37,8 @@ public abstract class AbstractColorMap extends TwoDimSampler {
         this.wheel = wheel;
     }
 
-    protected final GameImage drawBackground() {
+    @Override
+    final GameImage drawBackground() {
         final Theme t = Settings.getTheme();
         final int w = getWidth(),
                 h = getHeight();
@@ -65,7 +66,7 @@ public abstract class AbstractColorMap extends TwoDimSampler {
     }
 
     @Override
-    protected final void updateAssets(final Color c) {
+    final void updateAssets(final Color c) {
         final int w = getWidth(), h = getHeight(),
                 ew = getEffectiveWidth(), eh = getEffectiveHeight();
         final GameImage wheel = new GameImage(w, h);
@@ -98,16 +99,13 @@ public abstract class AbstractColorMap extends TwoDimSampler {
         setWheel(wheel.submit());
     }
 
-    abstract Color getPixelColor(final Color c, final Coord2D pixel);
-    abstract Coord2D getNodePos(final Color c);
-
     @Override
-    protected final int getEffectiveWidth() {
+    final int getEffectiveWidth() {
         return radius * 2;
     }
 
     @Override
-    protected final int getEffectiveHeight() {
+    final int getEffectiveHeight() {
         return radius * 2;
     }
 

--- a/src/com/jordanbunke/stipple_effect/visual/menu_elements/colors/AbstractColorMap.java
+++ b/src/com/jordanbunke/stipple_effect/visual/menu_elements/colors/AbstractColorMap.java
@@ -1,0 +1,118 @@
+package com.jordanbunke.stipple_effect.visual.menu_elements.colors;
+
+import com.jordanbunke.delta_time.image.GameImage;
+import com.jordanbunke.delta_time.utility.math.Bounds2D;
+import com.jordanbunke.delta_time.utility.math.Coord2D;
+import com.jordanbunke.stipple_effect.StippleEffect;
+import com.jordanbunke.stipple_effect.utility.Layout;
+import com.jordanbunke.stipple_effect.utility.settings.Settings;
+import com.jordanbunke.stipple_effect.visual.theme.SEColors;
+import com.jordanbunke.stipple_effect.visual.theme.Theme;
+
+import java.awt.*;
+
+public abstract class AbstractColorMap extends TwoDimSampler {
+    private GameImage wheel;
+    final GameImage background;
+
+    final int radius;
+    final Coord2D localOffset, middle;
+
+    AbstractColorMap(final Coord2D position, final Bounds2D dimensions) {
+        super(position, dimensions);
+
+        final int w = dimensions.width(), h = dimensions.height(),
+                minDim = Math.min(w, h);
+        radius = (minDim / 2) - BUFFER_PX;
+
+        localOffset = new Coord2D(BUFFER_PX + ((w - minDim) / 2),
+                BUFFER_PX + ((h - minDim) / 2));
+        middle = localOffset.displace(radius, radius);
+
+        background = drawBackground();
+        updateAssets(StippleEffect.get().getSelectedColor());
+    }
+
+    void setWheel(final GameImage wheel) {
+        this.wheel = wheel;
+    }
+
+    protected final GameImage drawBackground() {
+        final Theme t = Settings.getTheme();
+        final int w = getWidth(),
+                h = getHeight();
+        final GameImage background = new GameImage(w, h);
+
+        final Color light = t.checkerboard1, dark = t.checkerboard2;
+
+        final int squareDim = Layout.SLIDER_OFF_DIM / 4;
+
+        for (int x = 0; x < w; x += squareDim) {
+            for (int y = 0; y < h; y += squareDim) {
+                final Color square = (x + y) % 2 == 0 ? light : dark;
+
+                background.fillRectangle(square, x, y, squareDim, squareDim);
+            }
+        }
+
+        for (int x = 0; x < w; x++)
+            for (int y = 0; y < h; y++)
+                if (Coord2D.unitDistanceBetween(middle,
+                        new Coord2D(x, y)) >= radius)
+                    background.setRGB(x, y, SEColors.transparent().getRGB());
+
+        return background.submit();
+    }
+
+    @Override
+    protected final void updateAssets(final Color c) {
+        final int w = getWidth(), h = getHeight(),
+                ew = getEffectiveWidth(), eh = getEffectiveHeight();
+        final GameImage wheel = new GameImage(w, h);
+
+        // border
+        final int ox = localOffset.x, oy = localOffset.y;
+        wheel.drawOval(Settings.getTheme().buttonOutline,
+                2f * BORDER_PX, ox, oy, ew, eh);
+
+        // background
+        wheel.draw(background);
+
+        // wheel
+        for (int x = ox; x < ox + ew; x++) {
+            for (int y = oy; y < oy + eh; y++) {
+                final Coord2D p = new Coord2D(x, y);
+
+                if (Coord2D.unitDistanceBetween(middle, p) > radius)
+                    continue;
+
+                final Color pixel = getPixelColor(c, p);
+                wheel.dot(pixel, x, y);
+            }
+        }
+
+        // pointer
+        final Coord2D nodePos = getNodePos(c);
+        drawNode(wheel, nodePos.x, nodePos.y);
+
+        setWheel(wheel.submit());
+    }
+
+    abstract Color getPixelColor(final Color c, final Coord2D pixel);
+    abstract Coord2D getNodePos(final Color c);
+
+    @Override
+    protected final int getEffectiveWidth() {
+        return radius * 2;
+    }
+
+    @Override
+    protected final int getEffectiveHeight() {
+        return radius * 2;
+    }
+
+    @Override
+    public final void render(final GameImage canvas) {
+        draw(wheel, canvas);
+    }
+}

--- a/src/com/jordanbunke/stipple_effect/visual/menu_elements/colors/ColorWheel.java
+++ b/src/com/jordanbunke/stipple_effect/visual/menu_elements/colors/ColorWheel.java
@@ -33,6 +33,16 @@ public final class ColorWheel extends AbstractColorMap {
         return Geometry.projectPoint(middle, angle, distance);
     }
 
+    @Override
+    void updateColor(final Coord2D localMP) {
+        final double hue = getHue(localMP), sat = getSat(localMP);
+        final Color c = StippleEffect.get().getSelectedColor();
+
+        StippleEffect.get().setSelectedColor(
+                ColorMath.fromColorWheel(hue, sat, c),
+                ColorMath.LastHSVEdit.WHEEL);
+    }
+
     private double getHue(final Coord2D localMP) {
         final double angle = Geometry.normalizeAngle(
                 Geometry.calculateAngleInRad(localMP, middle));
@@ -44,15 +54,5 @@ public final class ColorWheel extends AbstractColorMap {
         final double distance = Coord2D.unitDistanceBetween(middle, localMP);
 
         return MathPlus.bounded(0d, distance / (double) radius, 1d);
-    }
-
-    @Override
-    protected void updateColor(final Coord2D localMP) {
-        final double hue = getHue(localMP), sat = getSat(localMP);
-        final Color c = StippleEffect.get().getSelectedColor();
-
-        StippleEffect.get().setSelectedColor(
-                ColorMath.fromColorWheel(hue, sat, c),
-                ColorMath.LastHSVEdit.WHEEL);
     }
 }

--- a/src/com/jordanbunke/stipple_effect/visual/menu_elements/colors/ColorWheel.java
+++ b/src/com/jordanbunke/stipple_effect/visual/menu_elements/colors/ColorWheel.java
@@ -1,111 +1,32 @@
 package com.jordanbunke.stipple_effect.visual.menu_elements.colors;
 
-import com.jordanbunke.delta_time.image.GameImage;
 import com.jordanbunke.delta_time.utility.math.Bounds2D;
 import com.jordanbunke.delta_time.utility.math.Coord2D;
 import com.jordanbunke.delta_time.utility.math.MathPlus;
 import com.jordanbunke.stipple_effect.StippleEffect;
 import com.jordanbunke.stipple_effect.utility.Constants;
-import com.jordanbunke.stipple_effect.utility.Layout;
 import com.jordanbunke.stipple_effect.utility.math.ColorMath;
 import com.jordanbunke.stipple_effect.utility.math.Geometry;
-import com.jordanbunke.stipple_effect.utility.settings.Settings;
-import com.jordanbunke.stipple_effect.visual.theme.SEColors;
-import com.jordanbunke.stipple_effect.visual.theme.Theme;
 
 import java.awt.*;
 
-public final class ColorWheel extends TwoDimSampler {
-    private GameImage wheel;
-    private final GameImage background;
-
-    private final int radius;
-    private final Coord2D localOffset, middle;
+public final class ColorWheel extends AbstractColorMap {
 
     public ColorWheel(final Coord2D position, final Bounds2D dimensions) {
         super(position, dimensions);
-
-        final int w = dimensions.width(), h = dimensions.height(),
-                minDim = Math.min(w, h);
-        radius = (minDim / 2) - BUFFER_PX;
-
-        localOffset = new Coord2D(BUFFER_PX + ((w - minDim) / 2),
-                BUFFER_PX + ((h - minDim) / 2));
-        middle = localOffset.displace(radius, radius);
-
-        background = drawBackground();
-        updateAssets(StippleEffect.get().getSelectedColor());
     }
 
     @Override
-    protected GameImage drawBackground() {
-        final Theme t = Settings.getTheme();
-        final int w = getWidth(),
-                h = getHeight();
-        final GameImage background = new GameImage(w, h);
-
-        final Color light = t.checkerboard1, dark = t.checkerboard2;
-
-        final int squareDim = Layout.SLIDER_OFF_DIM / 4;
-
-        for (int x = 0; x < w; x += squareDim) {
-            for (int y = 0; y < h; y += squareDim) {
-                final Color square = (x + y) % 2 == 0 ? light : dark;
-
-                background.fillRectangle(square, x, y, squareDim, squareDim);
-            }
-        }
-
-        for (int x = 0; x < w; x++)
-            for (int y = 0; y < h; y++)
-                if (Coord2D.unitDistanceBetween(middle,
-                        new Coord2D(x, y)) >= radius)
-                    background.setRGB(x, y, SEColors.transparent().getRGB());
-
-        return background.submit();
+    Color getPixelColor(Color c, Coord2D pixel) {
+        return ColorMath.fromHSV(getHue(pixel), getSat(pixel),
+                ColorMath.fetchValue(c), c.getAlpha());
     }
 
     @Override
-    protected void updateAssets(final Color c) {
-        final int w = getWidth(), h = getHeight(),
-                ew = getEffectiveWidth(), eh = getEffectiveHeight();
-        final GameImage wheel = new GameImage(w, h);
-
-        // border
-        final int ox = localOffset.x, oy = localOffset.y;
-        wheel.drawOval(Settings.getTheme().buttonOutline,
-                2f * BORDER_PX, ox, oy, ew, eh);
-
-        // background
-        wheel.draw(background);
-
+    Coord2D getNodePos(final Color c) {
         final double hue = ColorMath.fetchHue(c),
-                sat = ColorMath.fetchSat(c),
-                value = ColorMath.fetchValue(c);
+                sat = ColorMath.fetchSat(c);
 
-        // wheel
-        for (int x = ox; x < ox + ew; x++) {
-            for (int y = oy; y < oy + eh; y++) {
-                final Coord2D p = new Coord2D(x, y);
-
-                if (Coord2D.unitDistanceBetween(middle, p) > radius)
-                    continue;
-
-                final double pHue = getHue(p), pSat = getSat(p);
-                final Color pixel = ColorMath.fromHSV(
-                        pHue, pSat, value, c.getAlpha());
-                wheel.dot(pixel, x, y);
-            }
-        }
-
-        // pointer
-        final Coord2D nodePos = getNodePos(hue, sat);
-        drawNode(wheel, nodePos.x, nodePos.y);
-
-        this.wheel = wheel.submit();
-    }
-
-    private Coord2D getNodePos(final double hue, final double sat) {
         final double angle = hue * Constants.CIRCLE,
                 distance = sat * radius;
 
@@ -126,16 +47,6 @@ public final class ColorWheel extends TwoDimSampler {
     }
 
     @Override
-    protected int getEffectiveWidth() {
-        return radius * 2;
-    }
-
-    @Override
-    protected int getEffectiveHeight() {
-        return radius * 2;
-    }
-
-    @Override
     protected void updateColor(final Coord2D localMP) {
         final double hue = getHue(localMP), sat = getSat(localMP);
         final Color c = StippleEffect.get().getSelectedColor();
@@ -143,10 +54,5 @@ public final class ColorWheel extends TwoDimSampler {
         StippleEffect.get().setSelectedColor(
                 ColorMath.fromColorWheel(hue, sat, c),
                 ColorMath.LastHSVEdit.WHEEL);
-    }
-
-    @Override
-    public void render(final GameImage canvas) {
-        draw(wheel, canvas);
     }
 }

--- a/src/com/jordanbunke/stipple_effect/visual/menu_elements/colors/NormalMapSampler.java
+++ b/src/com/jordanbunke/stipple_effect/visual/menu_elements/colors/NormalMapSampler.java
@@ -12,7 +12,7 @@ import java.awt.*;
 public final class NormalMapSampler extends AbstractColorMap {
     public static final int NONE = 1, MAX = 50;
 
-    private static int quantization = MAX;
+    private static int quantization = NONE;
 
     public NormalMapSampler(final Coord2D position, final Bounds2D dimensions) {
         super(position, dimensions);
@@ -100,6 +100,20 @@ public final class NormalMapSampler extends AbstractColorMap {
 
     private boolean notQuantized() {
         return quantization == NONE;
+    }
+
+    public void setQuantization(final int quantization) {
+        NormalMapSampler.quantization =
+                MathPlus.bounded(NONE, quantization, MAX);
+
+        final Color c = StippleEffect.get().getSelectedColor(),
+                input = getPixelColor(c, getNodePos(c));
+
+        updateAssets(input);
+    }
+
+    public int getQuantization() {
+        return quantization;
     }
 
     private double vectorDim(final int channel) {

--- a/src/com/jordanbunke/stipple_effect/visual/menu_elements/colors/NormalMapSampler.java
+++ b/src/com/jordanbunke/stipple_effect/visual/menu_elements/colors/NormalMapSampler.java
@@ -2,30 +2,67 @@ package com.jordanbunke.stipple_effect.visual.menu_elements.colors;
 
 import com.jordanbunke.delta_time.utility.math.Bounds2D;
 import com.jordanbunke.delta_time.utility.math.Coord2D;
-import com.jordanbunke.stipple_effect.visual.theme.SEColors;
+import com.jordanbunke.delta_time.utility.math.MathPlus;
+import com.jordanbunke.stipple_effect.StippleEffect;
+import com.jordanbunke.stipple_effect.utility.Constants;
+import com.jordanbunke.stipple_effect.utility.math.ColorMath;
 
 import java.awt.*;
 
 public final class NormalMapSampler extends AbstractColorMap {
-
     public NormalMapSampler(final Coord2D position, final Bounds2D dimensions) {
         super(position, dimensions);
     }
 
     @Override
     Color getPixelColor(final Color c, final Coord2D pixel) {
-        // TODO
-        return SEColors.red();
+        final double x = x(pixel), y = y(pixel),
+                z = Math.sqrt(1d - ((x * x) + (y * y)));
+
+        return new Color(channel(x), channel(y),
+                channel(z), Constants.RGBA_SCALE);
     }
 
     @Override
     Coord2D getNodePos(final Color c) {
         // TODO
-        return middle;
+
+        final double x = vectorDim(c.getRed()),
+                y = vectorDim(c.getGreen());
+
+        return middle.displace(
+                (int)Math.round(x * radius),
+                (int)Math.round(-y * radius));
     }
 
     @Override
     void updateColor(final Coord2D localMP) {
-        // TODO
+        // TODO - test
+
+        final Color c = StippleEffect.get().getSelectedColor();
+
+        StippleEffect.get().setSelectedColor(
+                getPixelColor(c, localMP),
+                ColorMath.LastHSVEdit.NONE);
+    }
+
+    private double x(final Coord2D pixel) {
+        return MathPlus.bounded(-1d,
+                (pixel.x - middle.x) / (double) radius, 1d);
+    }
+
+    private double y(final Coord2D pixel) {
+        return MathPlus.bounded(-1d,
+                (middle.y - pixel.y) / (double) radius, 1d);
+    }
+
+    private int channel(final double vectorDim) {
+        final double adjusted = (vectorDim + 1d) / 2d;
+        return (int) Math.round(Constants.RGBA_SCALE * adjusted);
+    }
+
+    private double vectorDim(final int channel) {
+        final double scaled = channel / (double) Constants.RGBA_SCALE;
+        return (2d * scaled) - 1d;
     }
 }

--- a/src/com/jordanbunke/stipple_effect/visual/menu_elements/colors/NormalMapSampler.java
+++ b/src/com/jordanbunke/stipple_effect/visual/menu_elements/colors/NormalMapSampler.java
@@ -10,7 +10,7 @@ import com.jordanbunke.stipple_effect.utility.math.ColorMath;
 import java.awt.*;
 
 public final class NormalMapSampler extends AbstractColorMap {
-    public static final int NONE = 1, MAX = 50;
+    public static final int NONE = 1, MAX = 85, MIN_BLUE = 128;
 
     private static int quantization = NONE;
 
@@ -32,7 +32,7 @@ public final class NormalMapSampler extends AbstractColorMap {
 
         if (notQuantized()) {
             final double z = Math.sqrt(1d - ((x * x) + (y * y)));
-            return new Color(r, g, channel(z), Constants.RGBA_SCALE);
+            return new Color(r, g, blue(z), Constants.RGBA_SCALE);
         }
 
         // determines x and y from quantized red and green values
@@ -46,7 +46,7 @@ public final class NormalMapSampler extends AbstractColorMap {
         }
 
         final double z = Math.sqrt(1d - ((x * x) + (y * y)));
-        return new Color(r, g, channel(z), Constants.RGBA_SCALE);
+        return new Color(r, g, blue(z), Constants.RGBA_SCALE);
     }
 
     @Override
@@ -87,6 +87,16 @@ public final class NormalMapSampler extends AbstractColorMap {
     private int channel(final double vectorDim) {
         final double adjusted = (vectorDim + 1d) / 2d;
         return quantize((int) Math.round(Constants.RGBA_SCALE * adjusted));
+    }
+
+    private int blue(double z) {
+        if (Double.isNaN(z))
+            z = 0d;
+
+        final double adjusted = (z + 1d) / 2d;
+        int blue = quantize((int) Math.round(Constants.RGBA_SCALE * adjusted));
+
+        return Math.max(MIN_BLUE, blue);
     }
 
     private int quantize(final int input) {

--- a/src/com/jordanbunke/stipple_effect/visual/menu_elements/colors/NormalMapSampler.java
+++ b/src/com/jordanbunke/stipple_effect/visual/menu_elements/colors/NormalMapSampler.java
@@ -25,7 +25,7 @@ public final class NormalMapSampler extends AbstractColorMap {
     }
 
     @Override
-    protected void updateColor(final Coord2D localMP) {
+    void updateColor(final Coord2D localMP) {
         // TODO
     }
 }

--- a/src/com/jordanbunke/stipple_effect/visual/menu_elements/colors/NormalMapSampler.java
+++ b/src/com/jordanbunke/stipple_effect/visual/menu_elements/colors/NormalMapSampler.java
@@ -1,0 +1,31 @@
+package com.jordanbunke.stipple_effect.visual.menu_elements.colors;
+
+import com.jordanbunke.delta_time.utility.math.Bounds2D;
+import com.jordanbunke.delta_time.utility.math.Coord2D;
+import com.jordanbunke.stipple_effect.visual.theme.SEColors;
+
+import java.awt.*;
+
+public final class NormalMapSampler extends AbstractColorMap {
+
+    public NormalMapSampler(final Coord2D position, final Bounds2D dimensions) {
+        super(position, dimensions);
+    }
+
+    @Override
+    Color getPixelColor(final Color c, final Coord2D pixel) {
+        // TODO
+        return SEColors.red();
+    }
+
+    @Override
+    Coord2D getNodePos(final Color c) {
+        // TODO
+        return middle;
+    }
+
+    @Override
+    protected void updateColor(final Coord2D localMP) {
+        // TODO
+    }
+}

--- a/src/com/jordanbunke/stipple_effect/visual/menu_elements/colors/SatValMatrix.java
+++ b/src/com/jordanbunke/stipple_effect/visual/menu_elements/colors/SatValMatrix.java
@@ -24,7 +24,7 @@ public final class SatValMatrix extends TwoDimSampler {
     }
 
     @Override
-    protected GameImage drawBackground() {
+    GameImage drawBackground() {
         final Theme t = Settings.getTheme();
         final int w = getEffectiveWidth(),
                 h = getEffectiveHeight();
@@ -46,7 +46,7 @@ public final class SatValMatrix extends TwoDimSampler {
     }
 
     @Override
-    protected void updateAssets(final Color c) {
+    void updateAssets(final Color c) {
         final int w = getWidth(), h = getHeight();
         final GameImage matrix = new GameImage(w, h);
 
@@ -58,22 +58,14 @@ public final class SatValMatrix extends TwoDimSampler {
         // checkerboard background
         matrix.draw(background, BUFFER_PX, BUFFER_PX);
 
-        final double hue = ColorMath.fetchHue(c),
-                sat = ColorMath.fetchSat(c),
-                value = ColorMath.fetchValue(c);
-
         // matrix
-        for (int x = BUFFER_PX; x < w - BUFFER_PX; x++) {
-            for (int y = BUFFER_PX; y < h - BUFFER_PX; y++) {
-                final double pVal = getVal(x), pSat = getSat(y);
-                final Color pixel = ColorMath.fromHSV(
-                        hue, pSat, pVal, c.getAlpha());
-                matrix.dot(pixel, x, y);
-            }
-        }
+        for (int x = BUFFER_PX; x < w - BUFFER_PX; x++)
+            for (int y = BUFFER_PX; y < h - BUFFER_PX; y++)
+                matrix.dot(getPixelColor(c, new Coord2D(x, y)), x, y);
 
         // pointer
-        drawNode(matrix, getLocalXForVal(value), getLocalYForSat(sat));
+        final Coord2D nodePos = getNodePos(c);
+        drawNode(matrix, nodePos.x, nodePos.y);
 
         this.matrix = matrix.submit();
     }
@@ -101,17 +93,30 @@ public final class SatValMatrix extends TwoDimSampler {
     }
 
     @Override
-    protected int getEffectiveWidth() {
+    int getEffectiveWidth() {
         return getWidth() - (2 * BUFFER_PX);
     }
 
     @Override
-    protected int getEffectiveHeight() {
+    int getEffectiveHeight() {
         return getHeight() - (2 * BUFFER_PX);
     }
 
     @Override
-    protected void updateColor(final Coord2D localMP) {
+    Color getPixelColor(final Color c, final Coord2D pixel) {
+        return ColorMath.fromHSV(ColorMath.fetchHue(c), getSat(pixel.y),
+                getVal(pixel.x), c.getAlpha());
+    }
+
+    @Override
+    Coord2D getNodePos(final Color c) {
+        return new Coord2D(
+                getLocalXForVal(ColorMath.fetchValue(c)),
+                getLocalYForSat(ColorMath.fetchSat(c)));
+    }
+
+    @Override
+    void updateColor(final Coord2D localMP) {
         final double sat = getSat(localMP.y), value = getVal(localMP.x);
         final Color c = StippleEffect.get().getSelectedColor();
 

--- a/src/com/jordanbunke/stipple_effect/visual/menu_elements/colors/TwoDimSampler.java
+++ b/src/com/jordanbunke/stipple_effect/visual/menu_elements/colors/TwoDimSampler.java
@@ -26,21 +26,25 @@ public abstract class TwoDimSampler extends MenuElement {
     private double lastHue, lastSat, lastValue;
     private boolean interacting;
 
-    public TwoDimSampler(final Coord2D position, final Bounds2D dimensions) {
+    public TwoDimSampler(
+            final Coord2D position, final Bounds2D dimensions
+    ) {
         super(position, dimensions, Anchor.LEFT_TOP, true);
 
         interacting = false;
     }
 
-    protected abstract GameImage drawBackground();
+    abstract GameImage drawBackground();
 
-    protected abstract void updateColor(final Coord2D localMP);
+    abstract void updateAssets(final Color c);
 
-    protected abstract void updateAssets(final Color c);
+    abstract int getEffectiveWidth();
 
-    protected abstract int getEffectiveWidth();
+    abstract int getEffectiveHeight();
 
-    protected abstract int getEffectiveHeight();
+    abstract Color getPixelColor(final Color c, final Coord2D pixel);
+
+    abstract Coord2D getNodePos(final Color c);
 
     protected void drawNode(final GameImage img, final int x, final int y) {
         final GameImage node = GraphicsUtils.COLOR_NODE;
@@ -120,4 +124,6 @@ public abstract class TwoDimSampler extends MenuElement {
     ) {
 
     }
+
+    abstract void updateColor(final Coord2D localMP);
 }


### PR DESCRIPTION
### Added:
* Minimum values are enforced on startup for settings that could lead to crashes
* Extended the Color Picker tool with two alternate modes
  * Holding **Shift** searches layer by layer for the highest non-transparent color at the specified pixel; does nothing if no such pixel is found
  * Holding **Ctrl** samples the pixel from the flattened project
* Normal map color sampler with quantization option

### Fixed:
* Bug: Attempting to validate a script with no return type crashes the program
* Bug: Crashes due to impossible layout/sizing logic